### PR TITLE
Add `intel-llvm` as an option in meson config

### DIFF
--- a/config/meson.build
+++ b/config/meson.build
@@ -85,7 +85,7 @@ if la_backend == 'mkl' or la_backend == 'mkl-static'
       if get_option('openmp')
         libmkl_exe += cc.find_library('mkl_gnu_thread')
       endif
-    elif fc.get_id() == 'intel' or fc.get_id() == 'intel-cl'
+    elif fc.get_id() == 'intel' or fc.get_id() == 'intel-cl' of fc.get_id() == 'intel-llvm'
       libmkl_exe = [cc.find_library('mkl_intel_lp64')]
       if get_option('openmp')
         libmkl_exe += cc.find_library('mkl_intel_thread')


### PR DESCRIPTION
In order to compile CREST with Intel LLVM compilers, we need to add the option to all subprojects that are needed to build `CREST`. Since the classic compilers are deprecated, I would like to add this option, so that CREST can be build with intel compilers on HPC systems with the most recent Stages.